### PR TITLE
grepに-nオプションが指定されている場合に対応できるよう変更しました

### DIFF
--- a/cdd
+++ b/cdd
@@ -115,7 +115,7 @@ _cdd_cd() {
 
   local match="$(grep "^$key:" "$CDD_FILE")"
   if [ -n "$match" ]; then
-    local dir="${match#*:}"
+    local dir="${match##*:}"
     echo "cd $dir"
     cd "$(echo "$dir" | sed "s;^~;$HOME;")"
 


### PR DESCRIPTION
行番号を出すように grep に `-n` オプションを付けているため、CDD_FILEの該当行からディレクトリを取得する際に次のようなエラーが起きていました。

```
% alias grep='grep -n'
% cdd 6
cd 6:_,6.0:/usr/local/Cellar/zsh/5.0.1/share/zsh/functions
_cdd_cd:cd:12: no such file or directory: 6:_,6.0:/usr/local/Cellar/zsh/5.0.1/share/zsh/functions
```

ここにおけるパラメータ展開による置換は控えめである必要は無いと思いましたので、コロンより左をすべて取り除くよう変更しました。
