### PR TITLE
Support noclobber option.

### DIFF
--- a/cdd
+++ b/cdd
@@ -193,6 +193,8 @@ _cdd_register() {
   if [ -f "$CDD_FILE" ]; then
     sed -i.tmp -e "/^$key\:/d" "$CDD_FILE"
     rm -f "$CDD_FILE.tmp"
+  else
+    touch "$CDD_FILE"
   fi
 
   dir="$(echo "$dir" | sed "s;^$HOME;~;")"


### PR DESCRIPTION
cdd、大変便利に使わせてもらってます。:)

```
$ _cdd_chpwd
_cdd_register:10: no such file or directory: /Users/temmings/.cdd
_cdd_register:10: no such file or directory: /Users/temmings/.cdd
```
- `$CDD_FILE` が存在しない
- シェルが `noclobber` の設定で動いている

上記の条件で `$CDD_FILE` への追記に失敗していたため、
存在しない場合に touch するようにしました。
