### PR TITLE
Add a config file for antigen

### DIFF
--- a/cdd.plugin.zsh
+++ b/cdd.plugin.zsh
@@ -1,0 +1,5 @@
+source ${${0}:a:h}/cdd
+
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd _cdd_chpwd
+


### PR DESCRIPTION
zshのプラグインマネージャのantigen([zsh-users/antigen](https://github.com/zsh-users/antigen))向けの
設定ファイルを追加しました。

これでzshでantigenを使ってる方はantigenでm4i/cddを指定してインストールすると
zshrcへ (http://m4i.hatenablog.com/entry/2012/01/26/064329) にある設定の記述なしで
導入出来るようになります。
